### PR TITLE
STALE-BRANCH-BACKUP - How about we hibernate all supervisors?

### DIFF
--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -208,10 +208,11 @@
       Module :: module(),
       Args :: term().
 start_link(Mod, Args) ->
-    case Mod of
-        rabbit_channel_sup ->
+    case lists:suffix("_sup", atom_to_list(Mod)) of
+        true ->
+            %% hibernate supervisors
             gen_server:start_link(?MODULE, {self, Mod, Args}, [{hibernate_after, 1000}]);
-        _ ->
+        false ->
             gen_server:start_link(?MODULE, {self, Mod, Args}, [])
     end.
 

--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -208,7 +208,12 @@
       Module :: module(),
       Args :: term().
 start_link(Mod, Args) ->
-    gen_server:start_link(?MODULE, {self, Mod, Args}, []).
+    case Mod of
+        rabbit_channel_sup ->
+            gen_server:start_link(?MODULE, {self, Mod, Args}, [{hibernate_after, 1000}]);
+        _ ->
+            gen_server:start_link(?MODULE, {self, Mod, Args}, [])
+    end.
 
 -spec start_link(SupName, Module, Args) -> startlink_ret() when
       SupName :: sup_name(),


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 